### PR TITLE
Remove fastapi-mcp dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This project is an agentic workflow orchestration system built with the Model Co
 | Component       | Technology            | Purpose                                      |
 |-----------------|-----------------------|----------------------------------------------|
 | Framework       | FastAPI               | API server                                   |
-| MCP             | fastapi-mcp           | Agent orchestration                          |
+| MCP             | fastapi_mcp (stub)    | Agent orchestration                          |
 | Database        | SQLAlchemy, SQLite    | Persistent storage                           |
 | NLP             | openai                | ChatGPT summarization and embeddings         |
 | Email           | resend                | Notification delivery                        |
@@ -38,7 +38,6 @@ This project is an agentic workflow orchestration system built with the Model Co
 ## Dependencies
 
 - fastapi
-- fastapi-mcp
 - uvicorn
 - python-dotenv
 - openai
@@ -48,6 +47,7 @@ This project is an agentic workflow orchestration system built with the Model Co
 - python-docx
 - python-multipart
 - numpy
+- fastapi_mcp (included)
 
 ## Usage
 
@@ -97,3 +97,5 @@ Tools are available under `/mcp` for individual testing:
 - Use `OPENAI_API_KEY` for OpenAI access
 - Customize the `OPENAI_MODEL` environment variable to switch chat model.
   The sample `.env.example` uses `gpt-4.0` as the default model.
+- The `fastapi_mcp` module is bundled with the repository as a lightweight stub,
+  so there is no external `fastapi-mcp` package to install.

--- a/config.yaml
+++ b/config.yaml
@@ -7,7 +7,6 @@ project:
     - fastapi
     - uvicorn
     - python-dotenv
-    - fastapi-mcp
     - sqlalchemy
     - PyMuPDF
     - python-docx

--- a/fastapi_mcp.py
+++ b/fastapi_mcp.py
@@ -1,0 +1,30 @@
+from fastapi import APIRouter
+import inspect
+
+class MCPServer:
+    """Minimal stub of the fastapi-mcp library used for tests."""
+    def __init__(self, app, mount_path: str = "/mcp", **kwargs):
+        self.router = APIRouter()
+        app.include_router(self.router, prefix=mount_path)
+
+    def tool(self, path: str | None = None, methods: list[str] | None = None):
+        """Decorator to expose a function as an API endpoint."""
+        methods = methods or ["POST"]
+
+        def decorator(func):
+            endpoint = path or func.__name__
+
+            async def endpoint_func(*args, **kwargs):
+                result = func(*args, **kwargs)
+                if inspect.isawaitable(result):
+                    result = await result
+                return result
+
+            self.router.api_route(f"/{endpoint}", methods=methods)(endpoint_func)
+            return func
+
+        return decorator
+
+def add_mcp_server(app, **kwargs):
+    """Return a basic MCPServer instance and mount it."""
+    return MCPServer(app, **kwargs)

--- a/requirement.txt
+++ b/requirement.txt
@@ -1,7 +1,6 @@
 fastapi
 uvicorn
 python-dotenv
-fastapi-mcp
 sqlalchemy
 PyMuPDF
 python-docx


### PR DESCRIPTION
## Summary
- drop `fastapi-mcp` from `config.yaml`
- document the bundled stub in README

## Testing
- `./setup.sh` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686b020f81d4832095c820f8f7e9f857