### PR TITLE
Update README for pip install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,14 @@ This project is an agentic workflow orchestration system built with the Model Co
    python -m venv venv
    source venv/bin/activate
    ```
-4. Run `./setup.sh` to install the required Python packages listed in `requirement.txt`.
-   If you see `ModuleNotFoundError` errors when running the app, rerun
-   `pip install -r requirement.txt` inside the same virtual environment to
-   ensure all dependencies are installed.
+4. Install the required Python packages using your environment's Python:
+   ```bash
+   python -m pip install -r requirement.txt
+   ```
+   You can also run `./setup.sh`, which installs the same dependencies.
+   If you see `ModuleNotFoundError` errors when running the app, rerun the
+   above command inside the same virtual environment to ensure all dependencies
+   are installed.
 5. Ensure the `uploads` directory is writable.
 6. Run `python main.py` to start the API server (listens on `http://127.0.0.1:8000`).
 7. Open `http://localhost:8000` in your browser to access the web UI and API.


### PR DESCRIPTION
## Summary
- recommend using `python -m pip install -r requirement.txt` in the README
- mention that `./setup.sh` can also be used

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686f623069f883208b8daea079af61e5