### PR TITLE
Fix union syntax runtime error

### DIFF
--- a/fastapi_mcp.py
+++ b/fastapi_mcp.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from fastapi import APIRouter
 import inspect
 


### PR DESCRIPTION
## Summary
- prevent evaluation of union type hints on older Python versions

## Testing
- `python3 -m py_compile fastapi_mcp.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_686ffa5c8698832084667120eac980ee