### PR TITLE
Fix 405 error when submitting application

### DIFF
--- a/main.py
+++ b/main.py
@@ -46,8 +46,6 @@ app = FastAPI(
     version=config['version'],               # Use version from config
 )
 
-# Serve static UI from the "static" directory
-app.mount('/', StaticFiles(directory='static', html=True), name='static')
 
 # Mount MCP server to enable agentic tool calls
 mcp = add_mcp_server(
@@ -312,6 +310,9 @@ async def process_job_application(
         # Catch-all error
         log_error(f'Processing error: {e}')
         raise HTTPException(status_code=500, detail='Internal server error.')
+
+# Serve static UI after routes so API endpoints take precedence
+app.mount('/', StaticFiles(directory='static', html=True), name='static')
 
 # Entry point: run with Uvicorn when invoked directly
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- ensure the `StaticFiles` mount happens after API routes

## Testing
- `python -m py_compile main.py database.py fastapi_mcp.py`

------
https://chatgpt.com/codex/tasks/task_e_6870387314c483209eec50acba06b1da